### PR TITLE
Amendments to PR #73

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,4 +92,10 @@ repos:
       - id: mypy
         exclude: "alembic/versions"
         additional_dependencies:
-          ["starlite", "asyncpg", "types-redis", "types-requests"]
+          [
+            "starlite",
+            "git+https://github.com/sqlalchemy/sqlalchemy",
+            "asyncpg",
+            "types-redis",
+            "types-requests",
+          ]

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -16,7 +16,7 @@ convention = {
 }
 
 
-class Base(DeclarativeBase):  # type: ignore
+class Base(DeclarativeBase):
     """Base for all SQLAlchemy declarative models.
 
     Attributes
@@ -27,12 +27,10 @@ class Base(DeclarativeBase):  # type: ignore
         Date/time of last instance update.
     """
 
-    __name__: str
-
     table_name_pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
     # noinspection PyMethodParameters
-    @declared_attr  # type: ignore[misc]
+    @declared_attr.directive
     def __tablename__(cls) -> str:  # pylint: disable=no-self-argument
         return re.sub(cls.table_name_pattern, "_", cls.__name__).lower()
 

--- a/app/core/repository/repository.py
+++ b/app/core/repository/repository.py
@@ -112,7 +112,7 @@ class Repository(Generic[T_model]):
         ...
 
     @overload
-    async def execute(self, statement: "Executable", **kwargs: Any) -> "Result[Any]":  # type: ignore
+    async def execute(self, statement: "Executable", **kwargs: Any) -> "Result[Any]":
         ...
 
     async def execute(self, statement: "Executable", **kwargs: Any) -> "Result[Any]":

--- a/app/core/service.py
+++ b/app/core/service.py
@@ -56,7 +56,7 @@ class Service(Generic[T_model, T_repository, T_schema]):
         -------
         list[T_Schema]
         """
-        models: list[T_model] = await self.repository.scalars()
+        models = await self.repository.scalars()
         return [self.schema.from_orm(i) for i in models]
 
     async def update(self, data: T_schema) -> T_schema:

--- a/app/domain/entities/model.py
+++ b/app/domain/entities/model.py
@@ -1,8 +1,6 @@
-from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Column, Enum, ForeignKey, text
-from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy import Enum, ForeignKey, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.domain.model import InProviderDomain
@@ -14,6 +12,5 @@ class Entity(InProviderDomain):
     name: Mapped[str] = mapped_column(nullable=False)
     type: Mapped[Enum] = mapped_column(Enum(EntitiesEnum, create_constraint=False), nullable=False)
     owner_id: Mapped[UUID | None] = mapped_column(ForeignKey("entity.id"), index=True, nullable=True)
-    # ryno id is an implementation detail, not to be exposed to clients.
     ryno_id: Mapped[int] = mapped_column(index=True, nullable=True)
-    extra: Mapped[dict[str, Any]] = Column(pg.JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    extra: Mapped[dict] = mapped_column(server_default=text("'{}'::jsonb"))


### PR DESCRIPTION
- Adds sqlalchemy back to mypy pre-commit dependencies
- Use `declared_attr.directive` for `Base.__tablename__()`
- Fix typing of `Entity.extra` to match the type in the registry annotation map.